### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 PyConsul
 ========
 
-[![Latest Version](https://pypip.in/v/pyconsul/badge.png)](https://pypi.python.org/pypi/pyconsul/)
+[![Latest Version](https://img.shields.io/pypi/v/pyconsul.svg)](https://pypi.python.org/pypi/pyconsul/)
 [![Build Status](https://api.shippable.com/projects/535e1b4d456b81c100ad365c/badge/master)](https://www.shippable.com/projects/535e1b4d456b81c100ad365c/builds/4)
 [![Coverage Status](https://coveralls.io/repos/hackliff/pyconsul/badge.png?branch=master)](https://coveralls.io/r/hackliff/pyconsul?branch=master)
 [![Code Health](https://landscape.io/github/hackliff/pyconsul/master/landscape.png)](https://landscape.io/github/hackliff/pyconsul/master)
 [![Requirements Status](https://requires.io/github/hackliff/pyconsul/requirements.png?branch=master)](https://requires.io/github/hackliff/pyconsul/requirements/?branch=master)
-[![License](https://pypip.in/license/pyconsul/badge.png)](https://pypi.python.org/pypi/pyconsul/)
+[![License](https://img.shields.io/pypi/l/pyconsul.svg)](https://pypi.python.org/pypi/pyconsul/)
 
 > Python client for [Consul][1]
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyconsul))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyconsul`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.